### PR TITLE
added SoftwareSerial exclusion for raspberry pi pico

### DIFF
--- a/src/TMC2209.h
+++ b/src/TMC2209.h
@@ -9,7 +9,7 @@
 #define TMC2209_H
 #include <Arduino.h>
 
-#if !defined(ESP32) && !defined(SAMD_SERIES)
+#if !defined(ESP32) && !defined(SAMD_SERIES) && !defined(ARDUINO_RASPBERRY_PI_PICO)
 #  define SOFTWARE_SERIAL_IMPLEMENTED true
 #else
 #  define SOFTWARE_SERIAL_IMPLEMENTED false


### PR DESCRIPTION
I've found that the library insists on `#include <SoftwareSerial.h>` despite Arduino mbed OS for Raspberry Pi Pico not providing it. Is there a solution where SoftwareSerial is activated only for the appropriate target on a whitelist basis? eg. `defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_YUN)` I've found a list of constants [here](https://github.com/MattFryer/Board_Identify/blob/master/src/Board_Identify.h) if that helps.

For the curious I'm not actually using the Pico, but I'm modifying a RP2040-based board called the BigTreeTech SKR Pico, which has 4 onboard TMC2209 drivers.