### PR TITLE
add enableDoubleEdge(), disableDoubleEdge()

### DIFF
--- a/src/TMC2209.h
+++ b/src/TMC2209.h
@@ -88,6 +88,9 @@ public:
     uint8_t hold_current_percent,
     uint8_t hold_delay_percent);
 
+  void enableDoubleEdge();
+  void disableDoubleEdge();
+
   void enableInverseMotorDirection();
   void disableInverseMotorDirection();
 
@@ -492,6 +495,8 @@ private:
   const static uint8_t MRES_004 = 0b0110;
   const static uint8_t MRES_002 = 0b0111;
   const static uint8_t MRES_001 = 0b1000;
+  const static uint8_t DOUBLE_EDGE_DISABLE = 0;
+  const static uint8_t DOUBLE_EDGE_ENABLE = 1;
 
   const static size_t MICROSTEPS_PER_STEP_MIN = 1;
   const static size_t MICROSTEPS_PER_STEP_MAX = 256;

--- a/src/TMC2209/TMC2209.cpp
+++ b/src/TMC2209/TMC2209.cpp
@@ -224,6 +224,18 @@ void TMC2209::setAllCurrentValues(uint8_t run_current_percent,
   writeStoredDriverCurrent();
 }
 
+void TMC2209::enableDoubleEdge()
+{
+  chopper_config_.double_edge = DOUBLE_EDGE_DISABLE;
+  writeStoredChopperConfig();
+}
+
+void TMC2209::disableDoubleEdge()
+{
+  chopper_config_.double_edge = DOUBLE_EDGE_ENABLE;
+  writeStoredChopperConfig();
+}
+
 void TMC2209::enableInverseMotorDirection()
 {
   global_config_.shaft = 1;

--- a/src/TMC2209/TMC2209.cpp
+++ b/src/TMC2209/TMC2209.cpp
@@ -226,13 +226,13 @@ void TMC2209::setAllCurrentValues(uint8_t run_current_percent,
 
 void TMC2209::enableDoubleEdge()
 {
-  chopper_config_.double_edge = DOUBLE_EDGE_DISABLE;
+  chopper_config_.double_edge = DOUBLE_EDGE_ENABLE;
   writeStoredChopperConfig();
 }
 
 void TMC2209::disableDoubleEdge()
 {
-  chopper_config_.double_edge = DOUBLE_EDGE_ENABLE;
+  chopper_config_.double_edge = DOUBLE_EDGE_DISABLE;
   writeStoredChopperConfig();
 }
 


### PR DESCRIPTION
TMC2209's `DEDGE` mode appears to be much simpler to control (since you can just toggle your IO pin each step, instead of having to schedule a falling edge later according to the timing requirements)