### PR TITLE
Added support for ESP-IDF projects.

### DIFF
--- a/.github/workflows/build_examples_esp_idf_project.yml
+++ b/.github/workflows/build_examples_esp_idf_project.yml
@@ -1,0 +1,21 @@
+name: Build ESP-IDF example project
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: esp-idf build
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.3.2
+          target: esp32
+          path: examples/ESPIDFExample

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRC_DIRS "src/TMC2209"
+    INCLUDE_DIRS "src"
+    REQUIRES arduino-esp32
+)

--- a/examples/ESPIDFExample/.gitignore
+++ b/examples/ESPIDFExample/.gitignore
@@ -1,0 +1,5 @@
+/build
+/.vscode
+/managed_components
+/sdkconfig
+/dependencies.lock

--- a/examples/ESPIDFExample/CMakeLists.txt
+++ b/examples/ESPIDFExample/CMakeLists.txt
@@ -1,0 +1,10 @@
+# For more information about build system see
+# https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+project(idf_project_example)

--- a/examples/ESPIDFExample/README.md
+++ b/examples/ESPIDFExample/README.md
@@ -1,0 +1,8 @@
+This folder contains a bare bones functional ESP-IDF project.
+
+You can create one using the **ESP-IDF: New Project** command in
+Visual Studio code, or use this one as a basis. If you do use this one
+as a basis for your own project, review the `.gitignore` file as it
+excludes files you would not want to exclude in a normal project.
+Normally only the `managed_components` and `build` folders would be
+excluded from version control.

--- a/examples/ESPIDFExample/main/CMakeLists.txt
+++ b/examples/ESPIDFExample/main/CMakeLists.txt
@@ -1,0 +1,6 @@
+FILE(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.c ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+idf_component_register(
+    SRCS ${SOURCES}
+    INCLUDE_DIRS "."
+)

--- a/examples/ESPIDFExample/main/idf_component.yml
+++ b/examples/ESPIDFExample/main/idf_component.yml
@@ -1,0 +1,5 @@
+dependencies:
+  TMC2209:
+    path: ../../..
+    # Alternatively you can point this directly at the GitHub repository:
+    # git: https://github.com/janelia-arduino/TMC2209.git

--- a/examples/ESPIDFExample/main/main.cpp
+++ b/examples/ESPIDFExample/main/main.cpp
@@ -1,0 +1,129 @@
+#include <TMC2209.h>
+
+// This example will not work on Arduino boards without HardwareSerial ports,
+// such as the Uno, Nano, and Mini.
+//
+// See this reference for more details:
+// https://www.arduino.cc/reference/en/language/functions/communication/serial/
+
+HardwareSerial & serial_stream = Serial1;
+
+const long SERIAL_BAUD_RATE = 115200;
+const int DELAY = 2000;
+
+// Instantiate TMC2209
+TMC2209 stepper_driver;
+
+extern "C" void app_main()
+{
+  Serial.begin(SERIAL_BAUD_RATE);
+
+  stepper_driver.setup(serial_stream);
+
+  Serial.println("*************************");
+  Serial.println("getSettings()");
+  TMC2209::Settings settings = stepper_driver.getSettings();
+  Serial.print("settings.is_communicating = ");
+  Serial.println(settings.is_communicating);
+  Serial.print("settings.is_setup = ");
+  Serial.println(settings.is_setup);
+  Serial.print("settings.software_enabled = ");
+  Serial.println(settings.software_enabled);
+  Serial.print("settings.microsteps_per_step = ");
+  Serial.println(settings.microsteps_per_step);
+  Serial.print("settings.inverse_motor_direction_enabled = ");
+  Serial.println(settings.inverse_motor_direction_enabled);
+  Serial.print("settings.stealth_chop_enabled = ");
+  Serial.println(settings.stealth_chop_enabled);
+  Serial.print("settings.standstill_mode = ");
+  switch (settings.standstill_mode)
+  {
+    case TMC2209::NORMAL:
+      Serial.println("normal");
+      break;
+    case TMC2209::FREEWHEELING:
+      Serial.println("freewheeling");
+      break;
+    case TMC2209::STRONG_BRAKING:
+      Serial.println("strong_braking");
+      break;
+    case TMC2209::BRAKING:
+      Serial.println("braking");
+      break;
+  }
+  Serial.print("settings.irun_percent = ");
+  Serial.println(settings.irun_percent);
+  Serial.print("settings.irun_register_value = ");
+  Serial.println(settings.irun_register_value);
+  Serial.print("settings.ihold_percent = ");
+  Serial.println(settings.ihold_percent);
+  Serial.print("settings.ihold_register_value = ");
+  Serial.println(settings.ihold_register_value);
+  Serial.print("settings.iholddelay_percent = ");
+  Serial.println(settings.iholddelay_percent);
+  Serial.print("settings.iholddelay_register_value = ");
+  Serial.println(settings.iholddelay_register_value);
+  Serial.print("settings.automatic_current_scaling_enabled = ");
+  Serial.println(settings.automatic_current_scaling_enabled);
+  Serial.print("settings.automatic_gradient_adaptation_enabled = ");
+  Serial.println(settings.automatic_gradient_adaptation_enabled);
+  Serial.print("settings.pwm_offset = ");
+  Serial.println(settings.pwm_offset);
+  Serial.print("settings.pwm_gradient = ");
+  Serial.println(settings.pwm_gradient);
+  Serial.print("settings.cool_step_enabled = ");
+  Serial.println(settings.cool_step_enabled);
+  Serial.print("settings.analog_current_scaling_enabled = ");
+  Serial.println(settings.analog_current_scaling_enabled);
+  Serial.print("settings.internal_sense_resistors_enabled = ");
+  Serial.println(settings.internal_sense_resistors_enabled);
+  Serial.println("*************************");
+  Serial.println();
+
+  Serial.println("*************************");
+  Serial.println("hardwareDisabled()");
+  bool hardware_disabled = stepper_driver.hardwareDisabled();
+  Serial.print("hardware_disabled = ");
+  Serial.println(hardware_disabled);
+  Serial.println("*************************");
+  Serial.println();
+
+  Serial.println("*************************");
+  Serial.println("getStatus()");
+  TMC2209::Status status = stepper_driver.getStatus();
+  Serial.print("status.over_temperature_warning = ");
+  Serial.println(status.over_temperature_warning);
+  Serial.print("status.over_temperature_shutdown = ");
+  Serial.println(status.over_temperature_shutdown);
+  Serial.print("status.short_to_ground_a = ");
+  Serial.println(status.short_to_ground_a);
+  Serial.print("status.short_to_ground_b = ");
+  Serial.println(status.short_to_ground_b);
+  Serial.print("status.low_side_short_a = ");
+  Serial.println(status.low_side_short_a);
+  Serial.print("status.low_side_short_b = ");
+  Serial.println(status.low_side_short_b);
+  Serial.print("status.open_load_a = ");
+  Serial.println(status.open_load_a);
+  Serial.print("status.open_load_b = ");
+  Serial.println(status.open_load_b);
+  Serial.print("status.over_temperature_120c = ");
+  Serial.println(status.over_temperature_120c);
+  Serial.print("status.over_temperature_143c = ");
+  Serial.println(status.over_temperature_143c);
+  Serial.print("status.over_temperature_150c = ");
+  Serial.println(status.over_temperature_150c);
+  Serial.print("status.over_temperature_157c = ");
+  Serial.println(status.over_temperature_157c);
+  Serial.print("status.current_scaling = ");
+  Serial.println(status.current_scaling);
+  Serial.print("status.stealth_chop_mode = ");
+  Serial.println(status.stealth_chop_mode);
+  Serial.print("status.standstill = ");
+  Serial.println(status.standstill);
+  Serial.println("*************************");
+  Serial.println();
+
+  Serial.println();
+  delay(DELAY);
+}

--- a/examples/ESPIDFExample/sdkconfig.defaults
+++ b/examples/ESPIDFExample/sdkconfig.defaults
@@ -1,0 +1,2 @@
+# Required by the android-esp32 component.
+CONFIG_FREERTOS_HZ=1000

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,5 @@
+dependencies:
+  idf:
+    version: ">=5.3.0"
+  arduino-esp32:
+    version: "*"

--- a/src/TMC2209.h
+++ b/src/TMC2209.h
@@ -86,9 +86,15 @@ public:
   void setAllCurrentValues(uint8_t run_current_percent,
     uint8_t hold_current_percent,
     uint8_t hold_delay_percent);
+  void setRMSCurrent(uint16_t mA,
+    float rSense,
+    float holdMultiplier = 0.5f);
 
   void enableDoubleEdge();
   void disableDoubleEdge();
+
+  void enableVSense();
+  void disableVSense();
 
   void enableInverseMotorDirection();
   void disableInverseMotorDirection();
@@ -278,6 +284,9 @@ private:
 
   const static uint8_t STEPPER_DRIVER_FEATURE_OFF = 0;
   const static uint8_t STEPPER_DRIVER_FEATURE_ON = 1;
+
+  const static int MAX_READ_RETRIES = 5;
+  const static uint32_t READ_RETRY_DELAY_MS = 20;
 
   // Datagrams
   const static uint8_t WRITE_READ_REPLY_DATAGRAM_SIZE = 8;
@@ -504,6 +513,8 @@ private:
   const static uint8_t MRES_001 = 0b1000;
   const static uint8_t DOUBLE_EDGE_DISABLE = 0;
   const static uint8_t DOUBLE_EDGE_ENABLE = 1;
+  const static uint8_t VSENSE_DISABLE = 0;
+  const static uint8_t VSENSE_ENABLE = 1;
 
   const static size_t MICROSTEPS_PER_STEP_MIN = 1;
   const static size_t MICROSTEPS_PER_STEP_MAX = 256;

--- a/src/TMC2209.h
+++ b/src/TMC2209.h
@@ -285,7 +285,7 @@ private:
   const static uint8_t STEPPER_DRIVER_FEATURE_OFF = 0;
   const static uint8_t STEPPER_DRIVER_FEATURE_ON = 1;
 
-  const static int MAX_READ_RETRIES = 5;
+  const static uint8_t MAX_READ_RETRIES = 5;
   const static uint32_t READ_RETRY_DELAY_MS = 20;
 
   // Datagrams

--- a/src/TMC2209/TMC2209.cpp
+++ b/src/TMC2209/TMC2209.cpp
@@ -916,32 +916,43 @@ uint32_t TMC2209::read(uint8_t register_address)
   read_request_datagram.rw = RW_READ;
   read_request_datagram.crc = calculateCrc(read_request_datagram, READ_REQUEST_DATAGRAM_SIZE);
 
-  sendDatagramBidirectional(read_request_datagram, READ_REQUEST_DATAGRAM_SIZE);
-
-  uint32_t reply_delay = 0;
-  while ((serialAvailable() < WRITE_READ_REPLY_DATAGRAM_SIZE) and
-    (reply_delay < REPLY_DELAY_MAX_MICROSECONDS))
+  for (uint8_t retry = 0; retry < MAX_READ_RETRIES; retry++)
   {
-    delayMicroseconds(REPLY_DELAY_INC_MICROSECONDS);
-    reply_delay += REPLY_DELAY_INC_MICROSECONDS;
+    sendDatagramBidirectional(read_request_datagram, READ_REQUEST_DATAGRAM_SIZE);
+
+    uint32_t reply_delay = 0;
+    while ((serialAvailable() < WRITE_READ_REPLY_DATAGRAM_SIZE) and
+      (reply_delay < REPLY_DELAY_MAX_MICROSECONDS))
+    {
+      delayMicroseconds(REPLY_DELAY_INC_MICROSECONDS);
+      reply_delay += REPLY_DELAY_INC_MICROSECONDS;
+    }
+
+    if (reply_delay >= REPLY_DELAY_MAX_MICROSECONDS)
+    {
+      return 0;
+    }
+
+    uint64_t byte;
+    uint8_t byte_count = 0;
+    WriteReadReplyDatagram read_reply_datagram;
+    read_reply_datagram.bytes = 0;
+    for (uint8_t i=0; i<WRITE_READ_REPLY_DATAGRAM_SIZE; ++i)
+    {
+      byte = serialRead();
+      read_reply_datagram.bytes |= (byte << (byte_count++ * BITS_PER_BYTE));
+    }
+
+    auto crc = calculateCrc(read_reply_datagram, WRITE_READ_REPLY_DATAGRAM_SIZE);
+    if (crc == read_reply_datagram.crc)
+    {
+      return reverseData(read_reply_datagram.data);
+    }
+
+    delay(READ_RETRY_DELAY_MS);
   }
 
-  if (reply_delay >= REPLY_DELAY_MAX_MICROSECONDS)
-  {
-    return 0;
-  }
-
-  uint64_t byte;
-  uint8_t byte_count = 0;
-  WriteReadReplyDatagram read_reply_datagram;
-  read_reply_datagram.bytes = 0;
-  for (uint8_t i=0; i<WRITE_READ_REPLY_DATAGRAM_SIZE; ++i)
-  {
-    byte = serialRead();
-    read_reply_datagram.bytes |= (byte << (byte_count++ * BITS_PER_BYTE));
-  }
-
-  return reverseData(read_reply_datagram.data);
+  return 0;
 }
 
 uint8_t TMC2209::percentToCurrentSetting(uint8_t percent)


### PR DESCRIPTION
Added metadata and a sample project with a GitHub workflow action to demonstrate usage of this component in an ESP-IDF project.

This PR also contains the following changes:

* Added a helper method from the [TMCStepper](https://github.com/teemuatlut/TMCStepper) project to set the motor current by mA RMS.
* Automatically retry reading registers. I had quite a few problems reading register and with the retry in place, quite a few registers need to be read twice before a valid value is received. The logic is also taken from the TMCStepper project, but not the code.