### PR TITLE
fix TestUnoR4

### DIFF
--- a/examples/BidirectionalCommunication/TestUnoR4/TestUnoR4.ino
+++ b/examples/BidirectionalCommunication/TestUnoR4/TestUnoR4.ino
@@ -19,6 +19,9 @@ void setup()
 {
   Serial.begin(SERIAL_BAUD_RATE);
 
+  // Start Serial1 on pins 0 (RX) and 1 (TX)
+  Serial1.begin(SERIAL_BAUD_RATE);
+
   stepper_driver.setup(serial_stream);
 }
 


### PR DESCRIPTION
this library is very cool thank you!!

with the arduino R4 wifi I had to initialise the Serial1 port first or I got this error below.
this quick fix helped me but I am not sure this is the correct solution so please close this whenever.

```
Fault on interrupt or bare metal(no OS) environment
===== Thread stack information =====
  addr: 20007ec0    data: 2000026c
  addr: 20007ec4    data: 0000445b
  addr: 20007ec8    data: 00000000
  addr: 20007ecc    data: 00004040
  addr: 20007ed0    data: 0000a500
  addr: 20007ed4    data: 0000a1a1
  addr: 20007ed8    data: 00010b98
  addr: 20007edc    data: 40046f00
  addr: 20007ee0    data: 00000000
  addr: 20007ee4    data: 0000a1e7
  addr: 20007ee8    data: 00010b98
  addr: 20007eec    data: 00004613
  addr: 20007ef0    data: 00010b98
  addr: 20007ef4    data: 00007a87
  addr: 20007ef8    data: 00007a7d
  addr: 20007efc    data: 00002599
====================================
=================== Registers information ====================
  R0 : 064770be  R1 : e000e100  R2 : 000006e9  R3 : 056a1a10
  R12: 000000c4  LR : 0000445b  PC : 00004bae  PSR: 01000000
==============================================================
Bus fault is caused by precise data access violation
The bus fault occurred address is 056a1a30
```