### PR TITLE
Fix ESP32 HardwareSerial setup by skipping end() before begin()

### DIFF
--- a/src/TMC2209/TMC2209.cpp
+++ b/src/TMC2209/TMC2209.cpp
@@ -25,8 +25,14 @@ void TMC2209::setup(HardwareSerial & serial,
   SerialAddress serial_address)
 {
   hardware_serial_ptr_ = &serial;
+#if defined(ESP32)
+  // Avoid end() on ESP32 because it can leave the UART in a flaky state
+  // immediately before the first configuration writes.
+  hardware_serial_ptr_->begin(serial_baud_rate);
+#else
   hardware_serial_ptr_->end();
   hardware_serial_ptr_->begin(serial_baud_rate);
+#endif
 
   initialize(serial_baud_rate, serial_address);
 }


### PR DESCRIPTION
## Summary

Fixes ESP32 `HardwareSerial` setup by avoiding `serial.end()` in the generic `setup(HardwareSerial&, ...)` path.

The ESP32-specific overload already avoids `end()` and includes a comment saying it can cause issues on some ESP32 versions. The generic overload still called `end()`, and on ESP32-C3 that caused the initial TMC2209 `GCONF` setup write to fail intermittently.

## Problem

On my setup:

- MCU: ESP32-C3
- Board: LOLIN C3 Mini
- Driver: BIGTREETECH TMC2209 V1.3
- Framework: Arduino-ESP32 via PlatformIO

UART communication was partially working:

- `isCommunicating()` returned true
- `IFCNT` increased, so UART writes were succeeding
- other writable fields such as `shaft` and `freewheel` changed correctly

But during `setup()` the driver stayed in this state:

- `GCONF.pdn_disable = 0`
- `GCONF.mstep_reg_select = 0`
- `isSetupAndCommunicating()` returned false

As a result, microstep resolution continued to be taken from `MS1/MS2` pins instead of UART registers. With `MS1/MS2` floating, the driver stayed at 1/8 microstepping.

## Investigation

The key clue was that the ESP32-specific overload already contains this commented-out line:

```cpp
// hardware_serial_ptr_->end();  // Causes issues with some versions of ESP32
```
However, the generic setup(HardwareSerial&, ...) overload still did:

```cpp
hardware_serial_ptr_->end();
hardware_serial_ptr_->begin(serial_baud_rate);
``` 

In testing, a direct later write to GCONF worked immediately and correctly set:

pdn_disable = 1
mstep_reg_select = 1
After that, UART-controlled microstep writes worked normally.

That strongly suggested the problem was not wiring, CRC, or register definitions, but the end() call immediately before begin() on ESP32.

Fix
On ESP32, the generic setup(HardwareSerial&, ...) path now skips end() and only calls begin(...), matching the behavior of the ESP32-specific overload.

Result
After this change on ESP32-C3:

isSetupAndCommunicating() returns true
GCONF.pdn_disable = 1
GCONF.mstep_reg_select = 1
UART microstep configuration works as expected
Notes
This change is intentionally limited to ESP32 and preserves the previous behavior for other platforms.

